### PR TITLE
Code warnings and deprecations (#280)

### DIFF
--- a/src/main/java/eu/yals/utils/AppUtils.java
+++ b/src/main/java/eu/yals/utils/AppUtils.java
@@ -4,8 +4,6 @@ import com.google.common.base.CharMatcher;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.vaadin.flow.server.VaadinRequest;
-import com.vaadin.flow.server.VaadinSession;
-import com.vaadin.flow.server.WebBrowser;
 import eu.yals.constants.App;
 import eu.yals.constants.Header;
 import eu.yals.constants.MimeType;
@@ -227,28 +225,6 @@ public class AppUtils {
             log.debug("", e);
             throw new RuntimeException(e.getCause());
         }
-    }
-
-    /**
-     * Determines if client uses mobile OS (Android or iOS) to access site.
-     *
-     * @param vaadinSession valid {@link VaadinSession} from UI
-     * @return true, if client browser works on mobile operating system (Android or iOS), false - otherwise
-     */
-    public static boolean isMobile(final VaadinSession vaadinSession) {
-        WebBrowser browser = vaadinSession.getBrowser();
-        assert browser != null;
-        return browser.isIOS() || browser.isAndroid();
-    }
-
-    /**
-     * Opposite of {@link #isMobile(VaadinSession)}.
-     *
-     * @param vaadinSession valid {@link VaadinSession} from UI
-     * @return true, if client browser works on desktop operating system, false - otherwise
-     */
-    public static boolean isNotMobile(final VaadinSession vaadinSession) {
-        return !isMobile(vaadinSession);
     }
 
     /**

--- a/src/test/java/eu/yals/test/pageobjects/VaadinPageObject.java
+++ b/src/test/java/eu/yals/test/pageobjects/VaadinPageObject.java
@@ -3,7 +3,9 @@ package eu.yals.test.pageobjects;
 import com.codeborne.selenide.Configuration;
 import com.codeborne.selenide.SelenideElement;
 
-import static com.codeborne.selenide.Condition.disappears;
+import java.time.Duration;
+
+import static com.codeborne.selenide.Condition.hidden;
 import static com.codeborne.selenide.Selenide.$;
 
 /**
@@ -18,6 +20,6 @@ public class VaadinPageObject {
      * Ensures that site is loaded and Vaadin loading bar already disappear.
      */
     public static void waitForVaadin() {
-        $(LOADING_BAR).waitUntil(disappears, Configuration.timeout);
+        $(LOADING_BAR).shouldBe(hidden, Duration.ofMillis(Configuration.timeout));
     }
 }

--- a/src/test/java/eu/yals/test/utils/SelenideUtils.java
+++ b/src/test/java/eu/yals/test/utils/SelenideUtils.java
@@ -1,5 +1,7 @@
 package eu.yals.test.utils;
 
+import java.time.Duration;
+
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.title;
@@ -20,7 +22,7 @@ public class SelenideUtils {
      * @param durationInSeconds wait duration in seconds.
      */
     public static void waitUntilSiteLoads(int durationInSeconds) {
-        $("body").waitUntil(visible, durationInSeconds * 1000L);
+        $("body").shouldBe(visible, Duration.ofSeconds(durationInSeconds));
     }
 
     /**


### PR DESCRIPTION
* `AppUtils.isMobile()` and `AppUtils.isNotMobile()` no longer used and therefore removed
* Selenide `waitUntil()` deprecated and replaced with `shouldBe()`
Fix #280 