### PR TITLE
Wait until server is up. Smart server waiting before running tests (#303)

### DIFF
--- a/.github/workflows/ship2demo.yml
+++ b/.github/workflows/ship2demo.yml
@@ -40,8 +40,19 @@ jobs:
         with:
           args: -X POST ${{ secrets.DEMO_DEPLOY_HOOK }}
 
+      - name: Get deployed commit SHA
+        id: deployed_commit
+        run: echo "::set-output name=sha::$(echo $GITHUB_SHA | cut -c1-7)"
+
       - name: Wait for site appears online
-        run: sleep 120
+        uses: kyberorg/wait_for_new_version@v1.1
+        with:
+          url: https://demo.yals.ee
+          responseCode: 200
+          timeout: 120
+          interval: 1.5
+          hasActuator: true
+          commitSha: ${{ steps.deployed_commit.outputs.sha }}
 
       - name: Test App
         continue-on-error: true

--- a/.github/workflows/ship2dev.yml
+++ b/.github/workflows/ship2dev.yml
@@ -42,13 +42,13 @@ jobs:
 
       - name: Get deployed commit SHA
         id: deployed_commit
-        run: echo "::set-output name=sha::$(echo $GITHUB_SHA | cut -c1-8)"
+        run: echo "::set-output name=sha::$(echo $GITHUB_SHA | cut -c1-7)"
 
       - name: TMP echo
         run: echo ${{ steps.deployed_commit.outputs.sha }}
 
       - name: Wait for site appears online
-        uses: kyberorg/wait_for_new_version@trunk
+        uses: kyberorg/wait_for_new_version@v1.1
         with:
           url: https://dev.yals.ee
           responseCode: 200

--- a/.github/workflows/ship2dev.yml
+++ b/.github/workflows/ship2dev.yml
@@ -48,9 +48,9 @@ jobs:
         run: echo ${{ steps.deployed_commit.outputs.sha }}
 
       - name: Wait for site appears online
-        uses: kyberorg/wait_for_new_version@v1.1
+        uses: kyberorg/wait_for_new_version@trunk
         with:
-          url: 'https://dev.yals.ee'
+          url: https://dev.yals.ee
           responseCode: 200
           timeout: 120
           interval: 0.5

--- a/.github/workflows/ship2dev.yml
+++ b/.github/workflows/ship2dev.yml
@@ -53,7 +53,7 @@ jobs:
           url: https://dev.yals.ee
           responseCode: 200
           timeout: 120
-          interval: 0.5
+          interval: 1.5
           hasActuator: true
           commitSha: ${{ steps.deployed_commit.outputs.sha }}
 

--- a/.github/workflows/ship2dev.yml
+++ b/.github/workflows/ship2dev.yml
@@ -45,7 +45,7 @@ jobs:
         run: echo "::set-output name=sha::$(git rev-parse --short HEAD)"
 
       - name: Wait for site appears online
-        uses: kyberorg/wait_for_new_version@v1.0.2
+        uses: kyberorg/wait_for_new_version@v1.1
         with:
           url: 'https://dev.yals.ee'
           responseCode: 200

--- a/.github/workflows/ship2dev.yml
+++ b/.github/workflows/ship2dev.yml
@@ -44,9 +44,6 @@ jobs:
         id: deployed_commit
         run: echo "::set-output name=sha::$(echo $GITHUB_SHA | cut -c1-7)"
 
-      - name: TMP echo
-        run: echo ${{ steps.deployed_commit.outputs.sha }}
-
       - name: Wait for site appears online
         uses: kyberorg/wait_for_new_version@v1.1
         with:

--- a/.github/workflows/ship2dev.yml
+++ b/.github/workflows/ship2dev.yml
@@ -42,7 +42,10 @@ jobs:
 
       - name: Get deployed commit SHA
         id: deployed_commit
-        run: echo "::set-output name=sha::$(git rev-parse --short HEAD)"
+        run: echo "::set-output name=sha::$(echo $GITHUB_SHA | cut -c1-8)"
+
+      - name: TMP echo
+        run: echo ${{ steps.deployed_commit.sha }}
 
       - name: Wait for site appears online
         uses: kyberorg/wait_for_new_version@v1.1

--- a/.github/workflows/ship2dev.yml
+++ b/.github/workflows/ship2dev.yml
@@ -40,8 +40,19 @@ jobs:
         with:
           args: -X POST ${{ secrets.DEV_DEPLOY_HOOK }}
 
+      - name: Get deployed commit SHA
+        id: deployed_commit
+        run: echo "::set-output name=sha::$(git rev-parse --short HEAD)"
+
       - name: Wait for site appears online
-        run: sleep 120
+        uses: kyberorg/wait_for_new_version@v1.0.2
+        with:
+          url: 'https://dev.yals.ee'
+          responseCode: 200
+          timeout: 120
+          interval: 0.5
+          hasActuator: true
+          commitSha: ${{ steps.deployed_commit.sha }}
 
       - name: Test App
         continue-on-error: true

--- a/.github/workflows/ship2dev.yml
+++ b/.github/workflows/ship2dev.yml
@@ -45,7 +45,7 @@ jobs:
         run: echo "::set-output name=sha::$(echo $GITHUB_SHA | cut -c1-8)"
 
       - name: TMP echo
-        run: echo ${{ steps.deployed_commit.sha }}
+        run: echo ${{ steps.deployed_commit.outputs.sha }}
 
       - name: Wait for site appears online
         uses: kyberorg/wait_for_new_version@v1.1
@@ -55,7 +55,7 @@ jobs:
           timeout: 120
           interval: 0.5
           hasActuator: true
-          commitSha: ${{ steps.deployed_commit.sha }}
+          commitSha: ${{ steps.deployed_commit.outputs.sha }}
 
       - name: Test App
         continue-on-error: true


### PR DESCRIPTION
Migrated from dumb 2 mins waiting to [this GitHub Action](https://github.com/marketplace/actions/wait-for-new-version-deployed).
Fix #303 