### PR TITLE
Dependencies Bump (#408)

### DIFF
--- a/.github/workflows/buildTag.yml
+++ b/.github/workflows/buildTag.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Get Latest Tag
         id: get_tag
-        uses: WyriHaximus/github-action-get-previous-tag@1.0.0
+        uses: WyriHaximus/github-action-get-previous-tag@v1.1
 
       - name: Complile JAR
         run: mvn --batch-mode --update-snapshots clean package -P production-mode,noTesting

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run java checkstyle
-        uses: nikitasavinov/checkstyle-action@0.3.1
+        uses: nikitasavinov/checkstyle-action@0.4.0
         with:
           checkstyle_config: checkstyle.xml
           reporter: 'github-pr-check'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Java 11
         uses: actions/setup-java@v2.1.0
         with:
-          distribution: 'adopt-openj9'
+          distribution: 'adopt'
           java-version: '11'
           check-latest: true
           architecture: x64

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,9 +35,11 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Java 11
-        uses: actions/setup-java@v1.4.3
+        uses: actions/setup-java@v2.1.0
         with:
+          distribution: 'adopt-openj9'
           java-version: '11'
+          check-latest: true
           architecture: x64
 
       #- name: Adjust Maven Settings

--- a/.github/workflows/ship2demo.yml
+++ b/.github/workflows/ship2demo.yml
@@ -45,7 +45,7 @@ jobs:
         run: echo "::set-output name=sha::$(echo $GITHUB_SHA | cut -c1-7)"
 
       - name: Wait for site appears online
-        uses: kyberorg/wait_for_new_version@v1.1
+        uses: kyberorg/wait_for_new_version@v2
         with:
           url: https://demo.yals.ee
           responseCode: 200

--- a/.github/workflows/ship2demo.yml
+++ b/.github/workflows/ship2demo.yml
@@ -69,7 +69,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.7
+        uses: EnricoMi/publish-unit-test-result-action@v1.18
         if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ship2dev.yml
+++ b/.github/workflows/ship2dev.yml
@@ -69,7 +69,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.7
+        uses: EnricoMi/publish-unit-test-result-action@v1.18
         if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ship2dev.yml
+++ b/.github/workflows/ship2dev.yml
@@ -45,7 +45,7 @@ jobs:
         run: echo "::set-output name=sha::$(echo $GITHUB_SHA | cut -c1-7)"
 
       - name: Wait for site appears online
-        uses: kyberorg/wait_for_new_version@v1.1
+        uses: kyberorg/wait_for_new_version@v2
         with:
           url: https://dev.yals.ee
           responseCode: 200

--- a/.github/workflows/ship2prod.yml
+++ b/.github/workflows/ship2prod.yml
@@ -45,7 +45,7 @@ jobs:
         run: echo "::set-output name=sha::$(echo $GITHUB_SHA | cut -c1-7)"
 
       - name: Wait for site appears online
-        uses: kyberorg/wait_for_new_version@v1.1
+        uses: kyberorg/wait_for_new_version@v2
         with:
           url: https://yals.ee
           responseCode: 200

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.1</version>
+        <version>2.5.2</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
         <dependency>
             <groupId>com.codeborne</groupId>
             <artifactId>selenide</artifactId>
-            <version>5.22.0</version>
+            <version>5.22.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This PR fix #408

### Maven (`pom.xml`) updates
* Bump `Spring Boot`  `2.5.1` -> `2.5.2` (#401)
* Bump `selenide`  `5.22.0` -> `5.22.2` (#407) 

### GitHub Actions updates
* Bump `kyberorg/wait_for_new_version` `1.1` -> `2` (#399) 
* Bump EnricoMi/publish-unit-test-result-action `1.7` -> `1.18` (#400) 
* Bump `nikitasavinov/checkstyle-action` `0.3.1` -> `0.4.0` (#402)
* Bump `actions/setup-java` `1.4.3` -> `2.1.0` (#403)
* Bump `WyriHaximus/github-action-get-previous-tag` `1.0.0` -> `1.1` (#405)
