### PR TITLE
`UrlUtils.decodeUrl(String)` should throw more concrete exception (#442)

### DIFF
--- a/src/main/java/io/kyberorg/yalsee/exception/URLDecodeException.java
+++ b/src/main/java/io/kyberorg/yalsee/exception/URLDecodeException.java
@@ -1,0 +1,17 @@
+package io.kyberorg.yalsee.exception;
+
+/**
+ * Runtime exception that thrown when application it failed to decode URL.
+ *
+ * @since 3.2.1
+ */
+public class URLDecodeException extends RuntimeException {
+    /**
+     * Exception Constructor.
+     *
+     * @param cause UnsupportedEncodingException
+     */
+    public URLDecodeException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/io/kyberorg/yalsee/exception/URLDecodeException.java
+++ b/src/main/java/io/kyberorg/yalsee/exception/URLDecodeException.java
@@ -11,7 +11,7 @@ public class URLDecodeException extends RuntimeException {
      *
      * @param cause UnsupportedEncodingException
      */
-    public URLDecodeException(Throwable cause) {
+    public URLDecodeException(final Throwable cause) {
         super(cause);
     }
 }

--- a/src/main/java/io/kyberorg/yalsee/services/LinkService.java
+++ b/src/main/java/io/kyberorg/yalsee/services/LinkService.java
@@ -5,6 +5,7 @@ import io.kyberorg.yalsee.core.IdentGenerator;
 import io.kyberorg.yalsee.events.LinkDeletedEvent;
 import io.kyberorg.yalsee.events.LinkSavedEvent;
 import io.kyberorg.yalsee.events.LinkUpdatedEvent;
+import io.kyberorg.yalsee.exception.URLDecodeException;
 import io.kyberorg.yalsee.models.Link;
 import io.kyberorg.yalsee.models.LinkInfo;
 import io.kyberorg.yalsee.models.dao.LinkRepo;
@@ -228,7 +229,7 @@ public class LinkService {
             return OperationResult.success().addPayload(savedLink);
         } catch (CannotCreateTransactionException e) {
             return OperationResult.databaseDown();
-        } catch (RuntimeException decodeException) {
+        } catch (URLDecodeException decodeException) {
             log.error("{} {}", TAG, decodeException.getMessage());
             return OperationResult.generalFail().withMessage("Failed to decode URL");
         } catch (Exception e) {
@@ -285,7 +286,7 @@ public class LinkService {
             return OperationResult.success().addPayload(updatedLink);
         } catch (CannotCreateTransactionException e) {
             return OperationResult.databaseDown();
-        } catch (RuntimeException decodeException) {
+        } catch (URLDecodeException decodeException) {
             log.error("{} {}", TAG, decodeException.getMessage());
             return OperationResult.generalFail().withMessage("Failed to decode URL");
         } catch (Exception e) {

--- a/src/main/java/io/kyberorg/yalsee/utils/UrlUtils.java
+++ b/src/main/java/io/kyberorg/yalsee/utils/UrlUtils.java
@@ -1,5 +1,6 @@
 package io.kyberorg.yalsee.utils;
 
+import io.kyberorg.yalsee.exception.URLDecodeException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
@@ -113,14 +114,15 @@ public final class UrlUtils {
      *
      * @param encodedUrl string with URL where encoded chars are present or not
      * @return string with decoded URL or same string if URL has no chars to encode
+     * @throws URLDecodeException thrown when application it failed to decode URL.
      */
-    public static String decodeUrl(final String encodedUrl) {
+    public static String decodeUrl(final String encodedUrl) throws URLDecodeException {
         try {
             return URLDecoder.decode(encodedUrl, StandardCharsets.UTF_8.toString());
         } catch (UnsupportedEncodingException e) {
             log.error("{} Failed to decode URL", TAG);
             log.debug("", e);
-            throw new RuntimeException(e.getCause());
+            throw new URLDecodeException(e.getCause());
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Aleksandr Muravja <alex@kyberorg.io>