### PR TITLE
OperationResult can store multiple objects in payload (#613)

### DIFF
--- a/src/main/java/io/kyberorg/yalsee/result/OperationResult.java
+++ b/src/main/java/io/kyberorg/yalsee/result/OperationResult.java
@@ -3,6 +3,10 @@ package io.kyberorg.yalsee.result;
 import com.google.gson.internal.Primitives;
 import lombok.Getter;
 import lombok.ToString;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Class that defines result of operation. Operation can be any action: validation, query from database and so on.
@@ -47,11 +51,13 @@ public class OperationResult {
      */
     public static final String BANNED = "OP_NO_ACCESS";
 
+    private static final String DEFAULT_PAYLOAD_KEY = "DEFAULT_PAYLOAD_KEY";
+
     @Getter
     private String result;
     @Getter
     private String message;
-    private Object payload;
+    private final Map<String, Object> payload = new HashMap<>(1);
 
     /**
      * Default constructor.
@@ -169,18 +175,49 @@ public class OperationResult {
      * @return same object, but with added {@link #payload}
      */
     public OperationResult addPayload(final Object payload) {
-        this.payload = payload;
+        this.payload.put(DEFAULT_PAYLOAD_KEY, payload);
+        return this;
+    }
+
+    /**
+     * Stores payload under given key.
+     *
+     * @param key     key to store payload under.
+     * @param payload operation output object
+     * @return same object, but with added {@link #payload}
+     * @throws IllegalArgumentException if key is {@code null} or empty.
+     */
+    public OperationResult addPayload(final String key, final Object payload) {
+        if (StringUtils.isBlank(key)) {
+            throw new IllegalArgumentException("Key cannot be empty");
+        }
+        this.payload.put(key, payload);
         return this;
     }
 
     /**
      * Returns payload as a {@link String}.
      *
-     * @return string store in payload.
+     * @return string stored in payload.
      * @throws ClassCastException when payload contains something else but not {@link String}.
      */
     public String getStringPayload() {
         return getPayload(String.class);
+    }
+
+    /**
+     * Returns payload value, stored under given key as a {@link String}.
+     *
+     * @param key string with key payload stored under.
+     * @return string store in payload.
+     * @throws ClassCastException       when payload contains something else but not {@link String}.
+     * @throws IllegalArgumentException if key is {@code null} or empty.
+     */
+    public String getStringPayload(final String key) {
+        if (StringUtils.isBlank(key)) {
+            throw new IllegalArgumentException("Key cannot be empty");
+        }
+        return getPayload(key, String.class);
     }
 
     /**
@@ -194,6 +231,25 @@ public class OperationResult {
      */
     @SuppressWarnings("JavadocReference") //dynamic class param and example uses exact class to show usage.
     public <T> T getPayload(final Class<T> classOfPayload) {
-        return Primitives.wrap(classOfPayload).cast(this.payload);
+        return Primitives.wrap(classOfPayload).cast(this.payload.get(DEFAULT_PAYLOAD_KEY));
+    }
+
+    /**
+     * Returns payload value, stored under given key, cast to requested class.
+     * For example: {@link #getPayload(String, Long)} will return {@link Long} object.
+     *
+     * @param key            string with key payload stored under.
+     * @param classOfPayload class of object stored in {@link #payload}
+     * @param <T>            Java generics param.
+     * @return object stored in {@link #payload} converted to requested class.
+     * @throws ClassCastException       when payload contains something else, but not object of requested class.
+     * @throws IllegalArgumentException if key is {@code null} or empty.
+     */
+    @SuppressWarnings("JavadocReference") //dynamic class param and example uses exact class to show usage.
+    public <T> T getPayload(final String key, final Class<T> classOfPayload) {
+        if (StringUtils.isBlank(key)) {
+            throw new IllegalArgumentException("Key cannot be empty");
+        }
+        return Primitives.wrap(classOfPayload).cast(this.payload.get(key));
     }
 }

--- a/src/test/java/io/kyberorg/yalsee/test/unit/OperationResultTest.java
+++ b/src/test/java/io/kyberorg/yalsee/test/unit/OperationResultTest.java
@@ -1,0 +1,225 @@
+package io.kyberorg.yalsee.test.unit;
+
+import io.kyberorg.yalsee.models.Link;
+import io.kyberorg.yalsee.result.OperationResult;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.Issue;
+
+/**
+ * Test Suite for {@link OperationResult}.
+ *
+ * @since 3.7
+ */
+@Issue("https://github.com/kyberorg/yalsee/issues/613")
+public class OperationResultTest extends UnitTest {
+
+    /**
+     * Tests that {@link OperationResult#addPayload(Object)} adds Value.
+     */
+    @Test
+    public void addPayloadAddsValue() {
+        Link linkObject = new Link();
+        OperationResult operationResult = OperationResult.success().addPayload(linkObject);
+        Link storedObject = operationResult.getPayload(Link.class);
+        Assertions.assertEquals(linkObject, storedObject);
+    }
+
+    /**
+     * Tests that {@link OperationResult#addPayload(Object)} stores value under default Key.
+     */
+    @Test
+    public void addPayloadStoresUnderDefaultKey() {
+        String customKey = "MY_KEY";
+        Link linkObject = new Link();
+        OperationResult operationResult = OperationResult.success().addPayload(linkObject);
+        Link storedObject = operationResult.getPayload(customKey, Link.class);
+        Assertions.assertNull(storedObject);
+    }
+
+    /**
+     * Tests that {@link OperationResult#addPayload(Object)} can store {@code null}
+     * and {@link OperationResult#getPayload(Class)} can get it.
+     */
+    @Test
+    public void addPayloadStoresNullAndGetPayloadCanGetIt() {
+        OperationResult operationResult = OperationResult.success().addPayload(null);
+        Link storedObject = operationResult.getPayload(Link.class);
+        Assertions.assertNull(storedObject);
+    }
+
+    /**
+     * Tests that {@link OperationResult#getPayload(Class)} throws {@link ClassCastException}
+     * when wrong class requested.
+     */
+    @Test
+    public void getPayloadThrowsClassCastExceptionWhenWrongClassRequested() {
+        Assertions.assertThrows(ClassCastException.class, () -> {
+            Link linkObject = new Link();
+            OperationResult operationResult = OperationResult.success().addPayload(linkObject);
+            operationResult.getPayload(Boolean.class);
+        });
+    }
+
+    /**
+     * Tests that {@link OperationResult#getStringPayload()} provides stored {@link String}.
+     */
+    @Test
+    public void getStringPayloadGetsString() {
+        String str = "TheString";
+        OperationResult operationResult = OperationResult.success().addPayload(str);
+        String storedString = operationResult.getStringPayload();
+        Assertions.assertEquals(str, storedString);
+    }
+
+    /**
+     * Tests that {@link OperationResult#getStringPayload()} provides {@code null} if it is stored.
+     */
+    @Test
+    public void getStringPayloadCanGetNull() {
+        OperationResult operationResult = OperationResult.success().addPayload(null);
+        String storedString = operationResult.getStringPayload();
+        Assertions.assertNull(storedString);
+    }
+
+    /**
+     * Tests that {@link OperationResult#getStringPayload()} throws {@link ClassCastException}
+     * when stored non {@link String} object.
+     */
+    @Test
+    public void getStringPayloadThrowsClassCastExceptionWhenNotStringStored() {
+        Assertions.assertThrows(ClassCastException.class, () -> {
+            Link linkObject = new Link();
+            OperationResult operationResult = OperationResult.success().addPayload(linkObject);
+            operationResult.getStringPayload();
+        });
+    }
+
+    /**
+     * Tests that {@link OperationResult#addPayload(String, Object)} adds Value under given Key.
+     */
+    @Test
+    public void addPayloadWithKeyAddsValueUnderGivenKey() {
+        String customKey = "MY_KEY";
+        Link linkObject = new Link();
+        OperationResult operationResult = OperationResult.success().addPayload(customKey, linkObject);
+        Link storedObject = operationResult.getPayload(customKey, Link.class);
+        Assertions.assertEquals(linkObject, storedObject);
+    }
+
+    /**
+     * Tests that {@link OperationResult#addPayload(String, Object)} added value
+     * cannot be retrieved using {@link OperationResult#getPayload(Class)}.
+     */
+    @Test
+    public void addPayloadWithKeyStoresValueCannotBeRetrievedByDefaultMethod() {
+        String customKey = "MY_KEY";
+        Link linkObject = new Link();
+        OperationResult operationResult = OperationResult.success().addPayload(customKey, linkObject);
+        Link storedObject = operationResult.getPayload(Link.class);
+        Assertions.assertNull(storedObject);
+    }
+
+    /**
+     * Tests that {@link OperationResult#addPayload(String, Object)} can store {@code null} and
+     * {@link OperationResult#getPayload(String, Class)} can get it.
+     */
+    @Test
+    public void addPayloadWithKeyStoresNullAndGetPayloadWithKeyCanGetIt() {
+        String customKey = "MY_KEY";
+        OperationResult operationResult = OperationResult.success().addPayload(customKey, null);
+        Link storedObject = operationResult.getPayload(customKey, Link.class);
+        Assertions.assertNull(storedObject);
+    }
+
+    /**
+     * Tests that {@link OperationResult#addPayload(String, Object)} throws {@link IllegalArgumentException}
+     * when Key is {@code null}.
+     */
+    @Test
+    public void addPayloadWithKeyThrowsIllegalArgumentExceptionWhenKeyIsNull() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            String str = "storeMe";
+            OperationResult.success().addPayload(null, str);
+        });
+    }
+
+    /**
+     * Tests that {@link OperationResult#getPayload(String, Class)} throws {@link ClassCastException}
+     * when wrong class requested.
+     */
+    @Test
+    public void getPayloadWithKeyThrowsClassCastExceptionWhenWrongClassRequested() {
+        Assertions.assertThrows(ClassCastException.class, () -> {
+            String customKey = "MY_KEY";
+            Link linkObject = new Link();
+            OperationResult operationResult = OperationResult.success().addPayload(customKey, linkObject);
+            operationResult.getPayload(customKey, Boolean.class);
+        });
+    }
+
+    /**
+     * Tests that {@link OperationResult#getPayload(String, Class)} throws {@link IllegalArgumentException}
+     * when key is {@code null}.
+     */
+    @Test
+    public void getPayloadWithKeyThrowsIllegalArgumentExceptionWhenKeyIsNull() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            String customKey = "MY_KEY";
+            Link linkObject = new Link();
+            OperationResult operationResult = OperationResult.success().addPayload(customKey, linkObject);
+            operationResult.getPayload(null, Link.class);
+        });
+    }
+
+    /**
+     * Tests that {@link OperationResult#getStringPayload(String)} get {@link String} stored under given key.
+     */
+    @Test
+    public void getStringPayloadWithKeyGetsStringStoredUnderGivenKey() {
+        String customKey = "MY_KEY";
+        String str = "TheString";
+        OperationResult operationResult = OperationResult.success().addPayload(customKey, str);
+        String storedString = operationResult.getStringPayload(customKey);
+        Assertions.assertEquals(str, storedString);
+    }
+
+    /**
+     * Tests that {@link OperationResult#getStringPayload(String)} can get {@code null} stored.
+     */
+    @Test
+    public void getStringPayloadWithKeyCanGetNull() {
+        String customKey = "MY_KEY";
+        OperationResult operationResult = OperationResult.success().addPayload(customKey, null);
+        String storedString = operationResult.getStringPayload(customKey);
+        Assertions.assertNull(storedString);
+    }
+
+    /**
+     * Tests that {@link OperationResult#getStringPayload(String)} throws {@link ClassCastException}
+     * when wrong class requested.
+     */
+    @Test
+    public void getStringPayloadWithKeyThrowsClassCastExceptionWhenNotStringStored() {
+        Assertions.assertThrows(ClassCastException.class, () -> {
+            String customKey = "MY_KEY";
+            Link linkObject = new Link();
+            OperationResult operationResult = OperationResult.success().addPayload(customKey, linkObject);
+            operationResult.getStringPayload(customKey);
+        });
+    }
+
+    /**
+     * Tests that {@link OperationResult#getStringPayload(String)} throws {@link IllegalArgumentException}
+     * when key is {@code null}.
+     */
+    @Test
+    public void getStringPayloadWithKeyThrowsIllegalArgumentExceptionWhenKeyIsNull() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            String customKey = "MY_KEY";
+            String str = "TheString";
+            OperationResult operationResult = OperationResult.success().addPayload(customKey, str);
+            operationResult.getStringPayload(null);
+        });
+    }
+}


### PR DESCRIPTION
Signed-off-by: Aleksandr Muravja <alex@kyberorg.io>

Fix #613 