### PR TITLE
Allowed point, hyphen and underscore in idents (#616)

### DIFF
--- a/src/main/java/io/kyberorg/yalsee/core/IdentGenerator.java
+++ b/src/main/java/io/kyberorg/yalsee/core/IdentGenerator.java
@@ -13,6 +13,7 @@ public final class IdentGenerator {
     private static final int IDENT_MAX_LENGTH_WITHOUT_FIRST_AND_LAST_CHARS = IDENT_MAX_LENGTH - 2;
 
     /**
+     * Regexp explanation:
      * ^[a-zA-Z0-9]      # start with an alphanumeric character
      * (                 # start of (group 1)
      * [._-](?![._-])  # follow by a dot, hyphen, or underscore, negative lookahead to
@@ -26,7 +27,6 @@ public final class IdentGenerator {
      * # {0,IDENT_MAX_LENGTH - 2} plus the first and last alphanumeric characters,
      * # total length became {2, IDENT_MAX_LENGTH}
      */
-
     public static final String VALID_IDENT_PATTERN = "[a-zA-Z0-9]"
             + "([._-](?![._-])|[a-zA-Z0-9]){0," + IDENT_MAX_LENGTH_WITHOUT_FIRST_AND_LAST_CHARS + "} "
             + "[a-zA-Z0-9]$";

--- a/src/main/java/io/kyberorg/yalsee/core/IdentGenerator.java
+++ b/src/main/java/io/kyberorg/yalsee/core/IdentGenerator.java
@@ -10,7 +10,26 @@ import org.apache.commons.lang3.RandomStringUtils;
 public final class IdentGenerator {
     public static final int IDENT_DEFAULT_LENGTH = 6;
     private static final int IDENT_MAX_LENGTH = 255;
-    public static final String VALID_IDENT_PATTERN = "[a-zA-Z0-9]{2," + IDENT_MAX_LENGTH + "}";
+    private static final int IDENT_MAX_LENGTH_WITHOUT_FIRST_AND_LAST_CHARS = IDENT_MAX_LENGTH - 2;
+
+    /**
+     * ^[a-zA-Z0-9]      # start with an alphanumeric character
+     * (                 # start of (group 1)
+     * [._-](?![._-])  # follow by a dot, hyphen, or underscore, negative lookahead to
+     * # ensures dot, hyphen, and underscore does not appear consecutively
+     * |               # or
+     * [a-zA-Z0-9]     # an alphanumeric character
+     * )                 # end of (group 1)
+     * {0,IDENT_MAX_LENGTH - 2}  # ensures the length of (group 1) between 0 and IDENT_MAX_LENGTH - 2
+     * [a-zA-Z0-9]$      # end with an alphanumeric character
+     * <p>
+     * # {0,IDENT_MAX_LENGTH - 2} plus the first and last alphanumeric characters,
+     * # total length became {2, IDENT_MAX_LENGTH}
+     */
+
+    public static final String VALID_IDENT_PATTERN = "[a-zA-Z0-9]"
+            + "([._-](?![._-])|[a-zA-Z0-9]){0," + IDENT_MAX_LENGTH_WITHOUT_FIRST_AND_LAST_CHARS + "} "
+            + "[a-zA-Z0-9]$";
 
     private IdentGenerator() {
         throw new UnsupportedOperationException("Utility class");

--- a/src/main/java/io/kyberorg/yalsee/core/IdentGenerator.java
+++ b/src/main/java/io/kyberorg/yalsee/core/IdentGenerator.java
@@ -28,9 +28,8 @@ public final class IdentGenerator {
      * # {0,IDENT_MAX_LENGTH - 2} plus the first and last alphanumeric characters,
      * # total length became {2, IDENT_MAX_LENGTH}
      */
-    public static final String VALID_IDENT_PATTERN = "^[a-zA-Z0-9]"
-            + "([._-](?![._-])|[a-zA-Z0-9]){0," + IDENT_MAX_LENGTH_WITHOUT_FIRST_AND_LAST_CHARS + "} "
-            + "[a-zA-Z0-9]$";
+    public static final String VALID_IDENT_PATTERN = "^[a-zA-Z0-9]([._-](?![._-])|[a-zA-Z0-9]){0,"
+            + IDENT_MAX_LENGTH_WITHOUT_FIRST_AND_LAST_CHARS + "}[a-zA-Z0-9]$";
 
     private IdentGenerator() {
         throw new UnsupportedOperationException("Utility class");

--- a/src/main/java/io/kyberorg/yalsee/core/IdentGenerator.java
+++ b/src/main/java/io/kyberorg/yalsee/core/IdentGenerator.java
@@ -13,6 +13,7 @@ public final class IdentGenerator {
     private static final int IDENT_MAX_LENGTH_WITHOUT_FIRST_AND_LAST_CHARS = IDENT_MAX_LENGTH - 2;
 
     /**
+     * Ident pattern.
      * Regexp explanation:
      * ^[a-zA-Z0-9]      # start with an alphanumeric character
      * (                 # start of (group 1)
@@ -27,7 +28,7 @@ public final class IdentGenerator {
      * # {0,IDENT_MAX_LENGTH - 2} plus the first and last alphanumeric characters,
      * # total length became {2, IDENT_MAX_LENGTH}
      */
-    public static final String VALID_IDENT_PATTERN = "[a-zA-Z0-9]"
+    public static final String VALID_IDENT_PATTERN = "^[a-zA-Z0-9]"
             + "([._-](?![._-])|[a-zA-Z0-9]){0," + IDENT_MAX_LENGTH_WITHOUT_FIRST_AND_LAST_CHARS + "} "
             + "[a-zA-Z0-9]$";
 

--- a/src/test/java/io/kyberorg/yalsee/test/app/GetLinkApiTest.java
+++ b/src/test/java/io/kyberorg/yalsee/test/app/GetLinkApiTest.java
@@ -78,6 +78,193 @@ public class GetLinkApiTest extends UnirestTest {
     }
 
     /**
+     * Request with dot inside = 404.
+     */
+    @Test
+    public void onRequestWithDotInsideIdentStatusIs404() {
+        String ident = "a.b";
+        String url = TEST_URL + Endpoint.Api.LINKS_API + "/" + ident;
+        HttpRequest request = Unirest.get(url);
+        HttpResponse<String> result = request.asString();
+
+        logRequestAndResponse(request, result, TAG);
+
+        assertNotNull(result);
+        assertEquals(STATUS_200, result.getStatus());
+        TestUtils.assertResultIsYalsErrorJson(result);
+    }
+
+    /**
+     * Request with dot at first place = 400.
+     */
+    @Test
+    public void onRequestWithDotAsFirstCharIdentStatusIs400() {
+        String ident = ".b";
+        String url = TEST_URL + Endpoint.Api.LINKS_API + "/" + ident;
+        HttpRequest request = Unirest.get(url);
+        HttpResponse<String> result = request.asString();
+
+        logRequestAndResponse(request, result, TAG);
+
+        assertNotNull(result);
+        assertEquals(STATUS_400, result.getStatus());
+        TestUtils.assertResultIsYalsErrorJson(result);
+    }
+
+    /**
+     * Request with dot at last place = 400.
+     */
+    @Test
+    public void onRequestWithDotAsLastCharIdentStatusIs400() {
+        String ident = "b.";
+        String url = TEST_URL + Endpoint.Api.LINKS_API + "/" + ident;
+        HttpRequest request = Unirest.get(url);
+        HttpResponse<String> result = request.asString();
+
+        logRequestAndResponse(request, result, TAG);
+
+        assertNotNull(result);
+        assertEquals(STATUS_400, result.getStatus());
+        TestUtils.assertResultIsYalsErrorJson(result);
+    }
+
+    /**
+     * Request with hyphen inside = 404.
+     */
+    @Test
+    public void onRequestWithHyphenInsideIdentStatusIs200() {
+        String ident = "a-b";
+        String url = TEST_URL + Endpoint.Api.LINKS_API + "/" + ident;
+        HttpRequest request = Unirest.get(url);
+        HttpResponse<String> result = request.asString();
+
+        logRequestAndResponse(request, result, TAG);
+
+        assertNotNull(result);
+        assertEquals(STATUS_404, result.getStatus());
+        TestUtils.assertResultIsYalsErrorJson(result);
+    }
+
+    /**
+     * Request with dot at hyphen place = 400.
+     */
+    @Test
+    public void onRequestWithHyphenAsFirstCharIdentStatusIs400() {
+        String ident = "-b";
+        String url = TEST_URL + Endpoint.Api.LINKS_API + "/" + ident;
+        HttpRequest request = Unirest.get(url);
+        HttpResponse<String> result = request.asString();
+
+        logRequestAndResponse(request, result, TAG);
+
+        assertNotNull(result);
+        assertEquals(STATUS_400, result.getStatus());
+        TestUtils.assertResultIsYalsErrorJson(result);
+    }
+
+    /**
+     * Request with hyphen at last place = 400.
+     */
+    @Test
+    public void onRequestWithHyphenAsLastCharIdentStatusIs400() {
+        String ident = "b.";
+        String url = TEST_URL + Endpoint.Api.LINKS_API + "/" + ident;
+        HttpRequest request = Unirest.get(url);
+        HttpResponse<String> result = request.asString();
+
+        logRequestAndResponse(request, result, TAG);
+
+        assertNotNull(result);
+        assertEquals(STATUS_400, result.getStatus());
+        TestUtils.assertResultIsYalsErrorJson(result);
+    }
+
+    /**
+     * Request with underscore inside = 404.
+     */
+    @Test
+    public void onRequestWithUnderscoreInsideIdentStatusIs404() {
+        String ident = "a_b";
+        String url = TEST_URL + Endpoint.Api.LINKS_API + "/" + ident;
+        HttpRequest request = Unirest.get(url);
+        HttpResponse<String> result = request.asString();
+
+        logRequestAndResponse(request, result, TAG);
+
+        assertNotNull(result);
+        assertEquals(STATUS_404, result.getStatus());
+        TestUtils.assertResultIsYalsErrorJson(result);
+    }
+
+    /**
+     * Request with underscore at first place = 400.
+     */
+    @Test
+    public void onRequestWithUnderscoreAsFirstCharIdentStatusIs400() {
+        String ident = "_b";
+        String url = TEST_URL + Endpoint.Api.LINKS_API + "/" + ident;
+        HttpRequest request = Unirest.get(url);
+        HttpResponse<String> result = request.asString();
+
+        logRequestAndResponse(request, result, TAG);
+
+        assertNotNull(result);
+        assertEquals(STATUS_400, result.getStatus());
+        TestUtils.assertResultIsYalsErrorJson(result);
+    }
+
+    /**
+     * Request with underscore at last place = 400.
+     */
+    @Test
+    public void onRequestWithUnderscoreAsLastCharIdentStatusIs400() {
+        String ident = "b.";
+        String url = TEST_URL + Endpoint.Api.LINKS_API + "/" + ident;
+        HttpRequest request = Unirest.get(url);
+        HttpResponse<String> result = request.asString();
+
+        logRequestAndResponse(request, result, TAG);
+
+        assertNotNull(result);
+        assertEquals(STATUS_400, result.getStatus());
+        TestUtils.assertResultIsYalsErrorJson(result);
+    }
+
+    /**
+     * Request with allowed chars inside = 404.
+     */
+    @Test
+    public void onRequestWithAllowedCharsInsideIdentStatusIs404() {
+        String ident = "a_and-b.are.allowed";
+        String url = TEST_URL + Endpoint.Api.LINKS_API + "/" + ident;
+        HttpRequest request = Unirest.get(url);
+        HttpResponse<String> result = request.asString();
+
+        logRequestAndResponse(request, result, TAG);
+
+        assertNotNull(result);
+        assertEquals(STATUS_404, result.getStatus());
+        TestUtils.assertResultIsYalsErrorJson(result);
+    }
+
+    /**
+     * Request with allowed and not allowed together in ident = 400.
+     */
+    @Test
+    public void onRequestWithAllowedAndNotAllowedCharsTogetherInIdentStatusIs400() {
+        String ident = "b-#";
+        String url = TEST_URL + Endpoint.Api.LINKS_API + "/" + ident;
+        HttpRequest request = Unirest.get(url);
+        HttpResponse<String> result = request.asString();
+
+        logRequestAndResponse(request, result, TAG);
+
+        assertNotNull(result);
+        assertEquals(STATUS_400, result.getStatus());
+        TestUtils.assertResultIsYalsErrorJson(result);
+    }
+
+    /**
      * Request something that not exists = 404.
      */
     @Test

--- a/src/test/java/io/kyberorg/yalsee/test/app/GetLinkApiTest.java
+++ b/src/test/java/io/kyberorg/yalsee/test/app/GetLinkApiTest.java
@@ -90,7 +90,7 @@ public class GetLinkApiTest extends UnirestTest {
         logRequestAndResponse(request, result, TAG);
 
         assertNotNull(result);
-        assertEquals(STATUS_200, result.getStatus());
+        assertEquals(STATUS_404, result.getStatus());
         TestUtils.assertResultIsYalsErrorJson(result);
     }
 


### PR DESCRIPTION
Signed-off-by: Aleksandr Muravja <alex@kyberorg.io>

Fix #616