### PR TITLE
Docker Base Image: Distroless -> Alpine/Amazoncorretto (#882)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM amazoncorretto:11 as builder
+FROM kio.ee/hub/library/amazoncorretto:17-alpine as builder
 
 COPY target/yalsee.jar yalsee.jar
 RUN java -Djarmode=layertools -jar yalsee.jar extract
 
-FROM kio.ee/kyberorg/yalsee-base:distroless-jdk-11 as runner
+FROM kio.ee/yalsee/base:alpine-jre-17 as runner
 
 WORKDIR /app
 COPY --from=builder  dependencies/ ./

--- a/Dockerfile.DEV
+++ b/Dockerfile.DEV
@@ -1,9 +1,9 @@
-FROM amazoncorretto:11 as builder
+FROM kio.ee/hub/library/amazoncorretto:17-alpine as builder
 
 COPY target/yalsee.jar yalsee.jar
 RUN java -Djarmode=layertools -jar yalsee.jar extract
 
-FROM kio.ee/kyberorg/yalsee-base:distroless-jdk-17 as runner
+FROM kio.ee/yalsee/base:alpine-jdk-17 as runner
 
 WORKDIR /app
 COPY --from=builder  dependencies/ ./

--- a/Dockerfile.PROD
+++ b/Dockerfile.PROD
@@ -1,9 +1,9 @@
-FROM amazoncorretto:11 as builder
+FROM kio.ee/hub/library/amazoncorretto:17-alpine as builder
 
 COPY target/yalsee.jar yalsee.jar
 RUN java -Djarmode=layertools -jar yalsee.jar extract
 
-FROM kio.ee/kyberorg/yalsee-base:distroless-jre-17 as runner
+FROM kio.ee/yalsee/base:alpine-jre-17 as runner
 
 WORKDIR /app
 COPY --from=builder  dependencies/ ./

--- a/docker/base-image/Dockerfile.golang
+++ b/docker/base-image/Dockerfile.golang
@@ -1,3 +1,0 @@
-FROM golang:1.18.2-bullseye
-LABEL maintainer="Aleksandr Muravja <alex@kyberorg.io>"
-RUN set -eux; apt-get update; apt-get -y --no-install-recommends upgrade; rm -rf /var/lib/apt/lists/*

--- a/docker/base-image/Dockerfile.jdk
+++ b/docker/base-image/Dockerfile.jdk
@@ -1,4 +1,4 @@
-FROM kio.ee/kyberorg/golang:1.18.2 as healthcheckBuild
+FROM kio.ee/lib/golang:1.18.3-alpine as healthcheckBuild
 WORKDIR /go/src/app
 
 COPY cmd/healthcheck.go cmd/healthcheck.go
@@ -6,21 +6,23 @@ COPY cmd/healthcheck.go cmd/healthcheck.go
 RUN  GO111MODULE=off CGO_ENABLED=0 go install ./...
 
 # Set ownership and permissions as required
-# 65532 - is nonroot @ distroless. See: https://github.com/GoogleContainerTools/distroless/issues/235
+# 65532 - is appuser @runner.
 RUN mkdir /app && chown -R 65532:65532 /app
 
-FROM kio.ee/kyberorg/golang:1.18.2 as entrypointBuild
+FROM kio.ee/lib/golang:1.18.3-alpine as entrypointBuild
 WORKDIR /go/src/app
 COPY cmd/entrypoint.go cmd/entrypoint.go
 
 RUN  GO111MODULE=off CGO_ENABLED=0 go install ./...
 
-FROM gcr.io/distroless/java17-debian11:debug-nonroot as runner
+FROM kio.ee/lib/eclipse-temurin:17-jdk-alpine as runner
 LABEL maintainer="Aleksandr Muravja <alex@kyberorg.io>"
 COPY --from=healthcheckBuild /go/bin/cmd /app/healthcheck
 COPY --from=entrypointBuild /go/bin/cmd /app/entrypoint
 
 HEALTHCHECK --start-period=60s --interval=5s --timeout=20s --retries=3 CMD ["/app/healthcheck"]
 
-USER nonroot
+RUN addgroup -S --gid 65532  appgroup && adduser -S appuser --uid 65532 -G appgroup
+USER appuser
+
 ENTRYPOINT ["/app/entrypoint"]

--- a/docker/base-image/Dockerfile.jre
+++ b/docker/base-image/Dockerfile.jre
@@ -1,4 +1,4 @@
-FROM kio.ee/kyberorg/golang:1.18.2 as healthcheckBuild
+FROM kio.ee/lib/golang:1.18.3-alpine as healthcheckBuild
 WORKDIR /go/src/app
 
 COPY cmd/healthcheck.go cmd/healthcheck.go
@@ -6,21 +6,23 @@ COPY cmd/healthcheck.go cmd/healthcheck.go
 RUN  GO111MODULE=off CGO_ENABLED=0 go install ./...
 
 # Set ownership and permissions as required
-# 65532 - is nonroot @ distroless. See: https://github.com/GoogleContainerTools/distroless/issues/235
+# 65532 - is appuser @runner.
 RUN mkdir /app && chown -R 65532:65532 /app
 
-FROM kio.ee/kyberorg/golang:1.18.2 as entrypointBuild
+FROM kio.ee/lib/golang:1.18.3-alpine as entrypointBuild
 WORKDIR /go/src/app
 COPY cmd/entrypoint.go cmd/entrypoint.go
 
 RUN  GO111MODULE=off CGO_ENABLED=0 go install ./...
 
-FROM gcr.io/distroless/java17-debian11:nonroot as runner
+FROM kio.ee/lib/eclipse-temurin:17-jre-alpine as runner
 LABEL maintainer="Aleksandr Muravja <alex@kyberorg.io>"
 COPY --from=healthcheckBuild /go/bin/cmd /app/healthcheck
 COPY --from=entrypointBuild /go/bin/cmd /app/entrypoint
 
 HEALTHCHECK --start-period=60s --interval=5s --timeout=20s --retries=3 CMD ["/app/healthcheck"]
 
-USER nonroot
+RUN addgroup -S --gid 65532  appgroup && adduser -S appuser --uid 65532 -G appgroup
+USER appuser
+
 ENTRYPOINT ["/app/entrypoint"]

--- a/docker/base-image/create-golang.sh
+++ b/docker/base-image/create-golang.sh
@@ -1,5 +1,0 @@
-docker login kio.ee
-docker pull golang:1.18.2-bullseye
-docker build -t kio.ee/kyberorg/golang:1.18.2 -f Dockerfile.golang .
-docker push kio.ee/kyberorg/golang:1.18.2
-docker logout kio.ee

--- a/docker/base-image/create-jdk.sh
+++ b/docker/base-image/create-jdk.sh
@@ -1,5 +1,6 @@
 docker login kio.ee
-docker pull gcr.io/distroless/java17-debian11:debug-nonroot
-docker build -t kio.ee/kyberorg/yalsee-base:distroless-jdk-17 -f Dockerfile.jdk .
-docker push kio.ee/kyberorg/yalsee-base:distroless-jdk-17
+docker pull kio.ee/lib/golang:1.18.3-alpine
+docker pull kio.ee/lib/eclipse-temurin:17-jdk-alpine
+docker build -t kio.ee/yalsee/base:alpine-jdk-17 -f Dockerfile.jdk .
+docker push kio.ee/yalsee/base:alpine-jdk-17
 docker logout kio.ee

--- a/docker/base-image/create-jre.sh
+++ b/docker/base-image/create-jre.sh
@@ -1,5 +1,6 @@
 docker login kio.ee
-docker pull gcr.io/distroless/java17-debian11:nonroot
-docker build -t kio.ee/kyberorg/yalsee-base:distroless-jre-17 -f Dockerfile.jre .
-docker push kio.ee/kyberorg/yalsee-base:distroless-jre-17
+docker pull kio.ee/lib/golang:1.18.3-alpine
+docker pull kio.ee/lib/eclipse-temurin:17-jre-alpine
+docker build -t kio.ee/yalsee/base:alpine-jre-17 -f Dockerfile.jre .
+docker push kio.ee/yalsee/base:alpine-jre-17
 docker logout kio.ee


### PR DESCRIPTION
Signed-off-by: Aleksandr Muravja <alex@kyberorg.io>

Fix #882 

- [x] Base image migrated to `kio.ee/lib/eclipse-temurin:17-jdk/jre-alpine`, which is copy of official DockerHub's `eclipse-temurin:17-jdk/jre-alpine`. Synced every day.
- [x]  Compiler migrated to `Amazon Corretto` version `17-alpine`
