### PR TITLE
Fixing Undertow CVE by Bumping Spring Boot to 2.7.3 (#939)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.3</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     


### PR DESCRIPTION
Signed-off-by: Aleksandr Muravja <alex@kyberorg.io>

Fix #939 